### PR TITLE
new features for your permutations lib

### DIFF
--- a/lib/permutation.rb
+++ b/lib/permutation.rb
@@ -60,7 +60,7 @@ class Permutation
     end
 
     # generate permutation list  
-    perm_list = b.map { |e| puts e; lut[e].pop }
+    perm_list = b.map { |e| lut[e].pop }
     return(Permutation.from_value(perm_list))
   end
   

--- a/lib/permutation.rb
+++ b/lib/permutation.rb
@@ -45,6 +45,49 @@ class Permutation
     perm.instance_variable_set(:@collection, collection)
     perm
   end
+  
+  # Builds a permutation that maps <code>initial</code> into 
+  # <code>final</code>.  Both arguments must be the same length and 
+  # must contain the same elements.  If these arrays contain duplicate 
+  # elements, the solution will not be unique.
+  def self.for_mapping(initial, final)
+    raise(ArgumentError, "Initial and final lists must be the same length") unless(initial.length == final.length)
+    
+    # build LUT
+    lut = Hash.new {|h,k| h[k] = Array.new}
+    initial.each_with_index do |e, index|
+      lut[e] = lut[e].push(index);
+    end
+    
+    # generate permutation list  
+    perm_list = final.map { |e| lut[e].pop }
+    return(Permutation.from_value(perm_list))
+  end
+  
+  # Shortcut to generate the identity permutation that has 
+  # Permutation#size <code>n</code> 
+  def self.identity(n)
+    return(Permutation.new(n,0))
+  end
+
+# Returns the identity permutation that has the same Permutation#size as this instance
+  def identity
+    # the 0 rank permutation is the identity
+    return(Permutation.identity(self.size))
+  end
+  
+  # Computes the nth power (ie the nth repeated permutation) of this 
+  # instance.  Negative powers are taken to be powers of the inverse.  
+  def power(n)
+    raise(ArgumentError, "Can only take integer powers of Permutation instances") unless n.is_a?(Integer)
+    if(n >= 0)
+      (1..n).inject(self.identity) {|s,e| s * self}
+    elsif(n < 0) # negative powers are taken to be powers of the inverse
+      -self.power(-n)
+    end
+  end
+  alias :^ :power
+
 
   # Returns the size of this permutation, a Fixnum.
   attr_reader :size

--- a/lib/permutation.rb
+++ b/lib/permutation.rb
@@ -46,21 +46,21 @@ class Permutation
     perm
   end
   
-  # Builds a permutation that maps <code>before</code> into 
-  # <code>after</code>.  Both arguments must be the same length and 
-  # must contain the same elements.  If these arrays contain duplicate 
-  # elements, the solution will not be unique.
-  def self.for_mapping(before, after)
-    raise(ArgumentError, "Initial and final lists must be the same length") unless(before.length == after.length)
+  # Builds a permutation that maps <code>a</code> into <code>b</code>.  
+  # Both arguments must be the same length and must contain the same 
+  # elements.  If these arrays contain duplicate elements, the solution 
+  # will not be unique.
+  def self.for_mapping(a, b)
+    raise(ArgumentError, "Initial and final lists must be the same length") unless(a.length == b.length)
     
     # build LUT
     lut = Hash.new {|h,k| h[k] = Array.new}
-    before.each_with_index do |e, index|
+    a.each_with_index do |e, index|
       lut[e] = lut[e].push(index);
     end
 
     # generate permutation list  
-    perm_list = after.map { |e| lut[e].pop }
+    perm_list = b.map { |e| puts e; lut[e].pop }
     return(Permutation.from_value(perm_list))
   end
   

--- a/lib/permutation.rb
+++ b/lib/permutation.rb
@@ -357,7 +357,8 @@ class Permutation
     @@fcache[n]
   end
 
-  def rank_indices(p)
+  def rank_indices(ind)
+    p = ind.dup # modified to work with a copy
     result = 0
     for i in 0...size
       result += p[i] * factorial(size - i - 1)

--- a/lib/permutation.rb
+++ b/lib/permutation.rb
@@ -46,21 +46,21 @@ class Permutation
     perm
   end
   
-  # Builds a permutation that maps <code>initial</code> into 
-  # <code>final</code>.  Both arguments must be the same length and 
+  # Builds a permutation that maps <code>before</code> into 
+  # <code>after</code>.  Both arguments must be the same length and 
   # must contain the same elements.  If these arrays contain duplicate 
   # elements, the solution will not be unique.
-  def self.for_mapping(initial, final)
-    raise(ArgumentError, "Initial and final lists must be the same length") unless(initial.length == final.length)
+  def self.for_mapping(before, after)
+    raise(ArgumentError, "Initial and final lists must be the same length") unless(before.length == after.length)
     
     # build LUT
     lut = Hash.new {|h,k| h[k] = Array.new}
-    initial.each_with_index do |e, index|
+    before.each_with_index do |e, index|
       lut[e] = lut[e].push(index);
     end
-    
+
     # generate permutation list  
-    perm_list = final.map { |e| lut[e].pop }
+    perm_list = after.map { |e| lut[e].pop }
     return(Permutation.from_value(perm_list))
   end
   

--- a/test/test.rb
+++ b/test/test.rb
@@ -249,4 +249,45 @@ class TC_Permutation < Test::Unit::TestCase
                    perm.map { |p| p.odd? })
     end
   end
+
+  def test_identity
+    a = ("A".."Z").to_a
+    b = a.shuffle
+    p = Permutation.for_mapping(a, b)
+    assert_equal(Permutation.identity(p.size), Permutation.from_value((0..25).to_a))
+    assert_equal(Permutation.identity(p.size), p.identity)
+    assert_equal(p * -p, p.identity)
+  end
+
+  def test_for_mapping
+    # basic
+    a0 = (0..99).to_a
+    b0 = a0.shuffle
+    ref = Permutation.from_value(b0)
+    assert_equal(Permutation.for_mapping(a0, b0), ref)
+    # random
+    a1 = ("A".."Z").to_a
+    b1 = a1.shuffle
+    p = Permutation.for_mapping(a1, b1)
+    assert_equal(p.project(a1), b1)
+    # duplicate elements
+    3.times { a1.push("Z") }
+    b1 = a1.shuffle
+    p = Permutation.for_mapping(a1, b1)
+    assert_equal(p.project(a1), b1)
+    # random objects
+    a2 = [Array.new, Hash.new, nil, 0]
+    b2 = [Hash.new, nil, Array.new, 0]
+    p = Permutation.for_mapping(a2, b2)
+    assert_equal(p.value, [1, 2, 0, 3])
+  end
+
+  def test_power
+    p = Permutation.new(100).random
+    assert_equal(p^2, p*p)
+    assert_equal(p^3, p*p*p)
+    assert_equal(p^4, p*p*p*p)
+    assert_equal(p^-1, -p)
+    assert_equal(p^-2, -p * -p)
+  end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -263,7 +263,7 @@ class TC_Permutation < Test::Unit::TestCase
     # basic
     a0 = (0..99).to_a
     b0 = a0.shuffle
-    ref = Permutation.from_value(b0)
+    ref = Permutation.from_value(b0.dup) # something about from_value clobbers b0
     assert_equal(Permutation.for_mapping(a0, b0), ref)
     # random
     a1 = ("A".."Z").to_a

--- a/test/test.rb
+++ b/test/test.rb
@@ -263,7 +263,7 @@ class TC_Permutation < Test::Unit::TestCase
     # basic
     a0 = (0..99).to_a
     b0 = a0.shuffle
-    ref = Permutation.from_value(b0.dup) # something about from_value clobbers b0
+    ref = Permutation.from_value(b0) # something about from_value clobbers b0
     assert_equal(Permutation.for_mapping(a0, b0), ref)
     # random
     a1 = ("A".."Z").to_a

--- a/test/test.rb
+++ b/test/test.rb
@@ -263,7 +263,7 @@ class TC_Permutation < Test::Unit::TestCase
     # basic
     a0 = (0..99).to_a
     b0 = a0.shuffle
-    ref = Permutation.from_value(b0) # something about from_value clobbers b0
+    ref = Permutation.from_value(b0)
     assert_equal(Permutation.for_mapping(a0, b0), ref)
     # random
     a1 = ("A".."Z").to_a


### PR DESCRIPTION
I added a couple of new features to your permutations lib for a toy project I'm working on.  They add the ability to construct permutations by example and computing permutation powers.  I also added a quick shortcuts to get identity permutations.  There are tests for these routines as well.

I did make one change to the rank_indices method to have it work with a copy of the provided indices.  If I didn't make that change, the array provided to Permutation#from_value seemed to end up broken after the call.

If you are still maintaining this, could you merge these changes in?  Thanks.
